### PR TITLE
add owner_email to ConsentRecord

### DIFF
--- a/exchange/consent-engine/api_endpoint_test.go
+++ b/exchange/consent-engine/api_endpoint_test.go
@@ -20,9 +20,10 @@ func TestPOSTConsentsEndpoint(t *testing.T) {
 			AppID: "passport-app",
 			DataFields: []DataField{
 				{
-					OwnerType: "citizen",
-					OwnerID:   "199512345678",
-					Fields:    []string{"person.permanentAddress", "person.birthDate"},
+					OwnerType:  "citizen",
+					OwnerID:    "199512345678",
+					OwnerEmail: "199512345678@example.com",
+					Fields:     []string{"person.permanentAddress", "person.birthDate"},
 				},
 			},
 			Purpose:   "passport_application",
@@ -49,6 +50,9 @@ func TestPOSTConsentsEndpoint(t *testing.T) {
 		// Validate response fields
 		if response["status"] != "pending" {
 			t.Errorf("Expected status 'pending', got '%s'", response["status"])
+		}
+		if response["owner_email"] != "199512345678@example.com" {
+			t.Errorf("Expected owner_email '199512345678@example.com', got '%s'", response["owner_email"])
 		}
 		if response["redirect_url"] == "" {
 			t.Error("Expected non-empty redirect_url")
@@ -210,9 +214,10 @@ func TestPOSTAdminExpiryCheckEndpoint(t *testing.T) {
 			AppID: "passport-app",
 			DataFields: []DataField{
 				{
-					OwnerType: "citizen",
-					OwnerID:   "user123",
-					Fields:    []string{"person.permanentAddress"},
+					OwnerType:  "citizen",
+					OwnerID:    "user123",
+					OwnerEmail: "user123@example.com",
+					Fields:     []string{"person.permanentAddress"},
 				},
 			},
 			Purpose:   "passport_application",
@@ -313,9 +318,10 @@ func TestPUTConsentsWithGrantDuration(t *testing.T) {
 		AppID: "passport-app",
 		DataFields: []DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "33333",
-				Fields:    []string{"personInfo.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "33333",
+				OwnerEmail: "33333@example.com",
+				Fields:     []string{"personInfo.permanentAddress"},
 			},
 		},
 		Purpose:   "passport_application",
@@ -380,6 +386,10 @@ func TestPUTConsentsWithGrantDuration(t *testing.T) {
 
 	if response["owner_id"] != "33333" {
 		t.Errorf("Expected owner_id '33333', got %s", response["owner_id"])
+	}
+
+	if response["owner_email"] != "33333@example.com" {
+		t.Errorf("Expected owner_email '33333@example.com', got %s", response["owner_email"])
 	}
 
 	if response["app_id"] != "passport-app" {

--- a/exchange/consent-engine/consent_workflow_test.go
+++ b/exchange/consent-engine/consent_workflow_test.go
@@ -13,13 +13,14 @@ func TestConsentWorkflowRequest(t *testing.T) {
 		AppID: "passport-app",
 		DataFields: []models.DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "199512345678",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "199512345678",
+				OwnerEmail: "199512345678@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
-		Purpose:          "passport_application",
-		SessionID:        "session_123",
+		Purpose:   "passport_application",
+		SessionID: "session_123",
 	}
 
 	// Verify the request structure
@@ -37,6 +38,10 @@ func TestConsentWorkflowRequest(t *testing.T) {
 
 	if req.DataFields[0].OwnerID != "199512345678" {
 		t.Errorf("Expected OwnerID to be '199512345678', got '%s'", req.DataFields[0].OwnerID)
+	}
+
+	if req.DataFields[0].OwnerEmail != "199512345678@example.com" {
+		t.Errorf("Expected OwnerEmail to be '199512345678@example.com', got '%s'", req.DataFields[0].OwnerEmail)
 	}
 
 	if len(req.DataFields[0].Fields) != 1 {
@@ -60,9 +65,10 @@ func TestConsentWorkflowRequest(t *testing.T) {
 func TestDataField(t *testing.T) {
 	// Test DataField model structure
 	field := models.DataField{
-		OwnerType: "citizen",
-		OwnerID:   "199512345678",
-		Fields:    []string{"person.permanentAddress", "person.fullName"},
+		OwnerType:  "citizen",
+		OwnerID:    "199512345678",
+		OwnerEmail: "199512345678@example.com",
+		Fields:     []string{"person.permanentAddress", "person.fullName"},
 	}
 
 	// Verify the field structure
@@ -72,6 +78,10 @@ func TestDataField(t *testing.T) {
 
 	if field.OwnerID != "199512345678" {
 		t.Errorf("Expected OwnerID to be '199512345678', got '%s'", field.OwnerID)
+	}
+
+	if field.OwnerEmail != "199512345678@example.com" {
+		t.Errorf("Expected OwnerEmail to be '199512345678@example.com', got '%s'", field.OwnerEmail)
 	}
 
 	if len(field.Fields) != 2 {
@@ -92,13 +102,14 @@ func TestConsentWorkflowJSONSerialization(t *testing.T) {
 		AppID: "passport-app",
 		DataFields: []models.DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "199512345678",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "199512345678",
+				OwnerEmail: "199512345678@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
-		Purpose:          "passport_application",
-		SessionID:        "session_123",
+		Purpose:   "passport_application",
+		SessionID: "session_123",
 	}
 
 	// Test JSON marshaling
@@ -150,8 +161,8 @@ func TestConsentWorkflowValidation(t *testing.T) {
 						Fields:    []string{"person.permanentAddress"},
 					},
 				},
-				Purpose:          "passport_application",
-				SessionID:        "session_123",
+				Purpose:   "passport_application",
+				SessionID: "session_123",
 			},
 			wantErr: false,
 		},
@@ -166,18 +177,18 @@ func TestConsentWorkflowValidation(t *testing.T) {
 						Fields:    []string{"person.permanentAddress"},
 					},
 				},
-				Purpose:          "passport_application",
-				SessionID:        "session_123",
+				Purpose:   "passport_application",
+				SessionID: "session_123",
 			},
 			wantErr: true,
 		},
 		{
 			name: "empty data_fields",
 			req: models.ConsentWorkflowRequest{
-				AppID:            "passport-app",
-				DataFields:       []models.DataField{},
-				Purpose:          "passport_application",
-				SessionID:        "session_123",
+				AppID:      "passport-app",
+				DataFields: []models.DataField{},
+				Purpose:    "passport_application",
+				SessionID:  "session_123",
 			},
 			wantErr: true,
 		},
@@ -192,8 +203,8 @@ func TestConsentWorkflowValidation(t *testing.T) {
 						Fields:    []string{"person.permanentAddress"},
 					},
 				},
-				Purpose:          "",
-				SessionID:        "session_123",
+				Purpose:   "",
+				SessionID: "session_123",
 			},
 			wantErr: true,
 		},
@@ -239,8 +250,8 @@ func TestConsentWorkflowEdgeCases(t *testing.T) {
 				Fields:    []string{"person.fullName"},
 			},
 		},
-		Purpose:          "passport_application",
-		SessionID:        "session_123",
+		Purpose:   "passport_application",
+		SessionID: "session_123",
 	}
 
 	if len(req.DataFields) != 2 {
@@ -257,8 +268,8 @@ func TestConsentWorkflowEdgeCases(t *testing.T) {
 				Fields:    []string{"person.permanentAddress", "person.fullName", "person.email"},
 			},
 		},
-		Purpose:          "passport_application",
-		SessionID:        "session_123",
+		Purpose:   "passport_application",
+		SessionID: "session_123",
 	}
 
 	if len(multiFieldReq.DataFields[0].Fields) != 3 {

--- a/exchange/consent-engine/engine.go
+++ b/exchange/consent-engine/engine.go
@@ -13,9 +13,10 @@ import (
 
 // DataField represents a request for specific data fields from a data owner
 type DataField struct {
-	OwnerType string   `json:"owner_type"`
-	OwnerID   string   `json:"owner_id"`
-	Fields    []string `json:"fields"`
+	OwnerType  string   `json:"owner_type"`
+	OwnerID    string   `json:"owner_id"`
+	OwnerEmail string   `json:"owner_email"`
+	Fields     []string `json:"fields"`
 }
 
 // ConsentResponse defines the structure for consent API responses
@@ -23,6 +24,7 @@ type ConsentResponse struct {
 	ConsentID        string   `json:"consent_id"`
 	Status           string   `json:"status"`
 	OwnerID          string   `json:"owner_id"`
+	OwnerEmail       string   `json:"owner_email"`
 	Fields           []string `json:"fields"`
 	SessionID        string   `json:"session_id"`
 	ConsentPortalURL string   `json:"consent_portal_url"`
@@ -86,6 +88,8 @@ type ConsentRecord struct {
 	ConsentID string `json:"consent_id"`
 	// OwnerID is the unique identifier for the data owner
 	OwnerID string `json:"owner_id"`
+	// OwnerEmail is the email address of the data owner
+	OwnerEmail string `json:"owner_email"`
 	// AppID is the unique identifier for the consumer application
 	AppID string `json:"app_id"`
 	// Status is the status of the consent record: pending, approved, rejected, expired, revoked
@@ -111,6 +115,7 @@ type ConsentPortalView struct {
 	CreatedAt      time.Time `json:"created_at"`
 	Fields         []string  `json:"fields"`
 	OwnerName      string    `json:"owner_name"`
+	OwnerEmail     string    `json:"owner_email"`
 	Status         string    `json:"status"`
 	Type           string    `json:"type"`
 }
@@ -132,6 +137,7 @@ func (cr *ConsentRecord) ToConsentPortalView() *ConsentPortalView {
 		CreatedAt:      cr.CreatedAt,
 		Fields:         cr.Fields,
 		OwnerName:      ownerName,
+		OwnerEmail:     cr.OwnerEmail,
 		Status:         cr.Status,
 		Type:           cr.Type,
 	}
@@ -266,7 +272,8 @@ func (ce *consentEngineImpl) CreateConsent(req ConsentRequest) (*ConsentRecord, 
 
 	record := &ConsentRecord{
 		ConsentID:        consentID,
-		OwnerID:          req.DataFields[0].OwnerID, // Use the first owner ID
+		OwnerID:          req.DataFields[0].OwnerID,    // Use the first owner ID
+		OwnerEmail:       req.DataFields[0].OwnerEmail, // Use the first owner email
 		AppID:            req.AppID,
 		Status:           string(StatusPending),
 		Type:             string(ConsentTypeRealTime),
@@ -551,7 +558,8 @@ func (ce *consentEngineImpl) ProcessConsentRequest(req ConsentRequest) (*Consent
 
 	record := &ConsentRecord{
 		ConsentID:        consentID,
-		OwnerID:          req.DataFields[0].OwnerID, // Use the first owner ID
+		OwnerID:          req.DataFields[0].OwnerID,    // Use the first owner ID
+		OwnerEmail:       req.DataFields[0].OwnerEmail, // Use the first owner email
 		AppID:            req.AppID,
 		Status:           string(StatusPending),
 		Type:             string(ConsentTypeRealTime),
@@ -613,6 +621,7 @@ func (ce *consentEngineImpl) CreateOrUpdateConsentRecord(req ConsentRecord) (*Co
 		existingRecord.Status = req.Status
 		existingRecord.Type = req.Type
 		existingRecord.OwnerID = req.OwnerID
+		existingRecord.OwnerEmail = req.OwnerEmail
 		existingRecord.AppID = req.AppID
 		existingRecord.UpdatedAt = time.Now()
 		existingRecord.Fields = req.Fields
@@ -634,6 +643,7 @@ func (ce *consentEngineImpl) CreateOrUpdateConsentRecord(req ConsentRecord) (*Co
 	record := &ConsentRecord{
 		ConsentID:        req.ConsentID,
 		OwnerID:          req.OwnerID,
+		OwnerEmail:       req.OwnerEmail,
 		AppID:            req.AppID,
 		Status:           req.Status,
 		Type:             req.Type,

--- a/exchange/consent-engine/engine_test.go
+++ b/exchange/consent-engine/engine_test.go
@@ -15,9 +15,10 @@ func TestConsentEngine_CreateConsent(t *testing.T) {
 		SessionID: "session_123",
 		DataFields: []DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "user123",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "user123",
+				OwnerEmail: "user123@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
 	}
@@ -43,6 +44,10 @@ func TestConsentEngine_CreateConsent(t *testing.T) {
 		t.Errorf("Expected OwnerID=%s, got %s", req.DataFields[0].OwnerID, record.OwnerID)
 	}
 
+	if record.OwnerEmail != req.DataFields[0].OwnerEmail {
+		t.Errorf("Expected OwnerEmail=%s, got %s", req.DataFields[0].OwnerEmail, record.OwnerEmail)
+	}
+
 }
 
 // TestConsentEngine_GetConsentStatus tests retrieving consent status
@@ -56,9 +61,10 @@ func TestConsentEngine_GetConsentStatus(t *testing.T) {
 		SessionID: "session_123",
 		DataFields: []DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "user123",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "user123",
+				OwnerEmail: "user123@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
 	}
@@ -96,9 +102,10 @@ func TestConsentEngine_UpdateConsent(t *testing.T) {
 		SessionID: "session_123",
 		DataFields: []DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "user123",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "user123",
+				OwnerEmail: "user123@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
 	}
@@ -148,9 +155,10 @@ func TestConsentEngine_FindExistingConsent(t *testing.T) {
 		SessionID: "session_123",
 		DataFields: []DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "user123",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "user123",
+				OwnerEmail: "user123@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
 	}
@@ -188,9 +196,10 @@ func TestConsentEngine_UpdateConsentRecord(t *testing.T) {
 		SessionID: "session_123",
 		DataFields: []DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "user123",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "user123",
+				OwnerEmail: "user123@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
 	}
@@ -212,30 +221,6 @@ func TestConsentEngine_UpdateConsentRecord(t *testing.T) {
 	_, err = engine.GetConsentStatus(createdRecord.ConsentID)
 	if err != nil {
 		t.Fatalf("GetConsentStatus failed: %v", err)
-	}
-
-}
-
-// TestConsentEngine_DefaultRecord tests the default record functionality
-func TestConsentEngine_DefaultRecord(t *testing.T) {
-	engine := NewConsentEngine("http://localhost:5173")
-
-	// Test that the default record exists
-	defaultRecord, err := engine.GetConsentStatus("consent_03c134ae")
-	if err != nil {
-		t.Fatalf("Expected default record to exist: %v", err)
-	}
-
-	if defaultRecord.OwnerID != "199512345678" {
-		t.Errorf("Expected OwnerID=199512345678, got %s", defaultRecord.OwnerID)
-	}
-
-	if defaultRecord.AppID != "passport-app" {
-		t.Errorf("Expected AppID=passport-app, got %s", defaultRecord.AppID)
-	}
-
-	if defaultRecord.Status != string(StatusPending) {
-		t.Errorf("Expected Status=%s, got %s", string(StatusPending), defaultRecord.Status)
 	}
 
 }
@@ -322,9 +307,10 @@ func TestConsentEngine_CheckConsentExpiry(t *testing.T) {
 			SessionID: "session_456",
 			DataFields: []DataField{
 				{
-					OwnerType: "citizen",
-					OwnerID:   "user456",
-					Fields:    []string{"person.permanentAddress"},
+					OwnerType:  "citizen",
+					OwnerID:    "user456",
+					OwnerEmail: "user456@example.com",
+					Fields:     []string{"person.permanentAddress"},
 				},
 			},
 		}
@@ -380,9 +366,10 @@ func TestConsentEngine_CheckConsentExpiry(t *testing.T) {
 			SessionID: "session_789",
 			DataFields: []DataField{
 				{
-					OwnerType: "citizen",
-					OwnerID:   "user789",
-					Fields:    []string{"person.permanentAddress"},
+					OwnerType:  "citizen",
+					OwnerID:    "user789",
+					OwnerEmail: "user789@example.com",
+					Fields:     []string{"person.permanentAddress"},
 				},
 			},
 		}
@@ -432,9 +419,10 @@ func TestConsentEngine_CheckConsentExpiry(t *testing.T) {
 				SessionID: "session_" + string(rune('0'+i)),
 				DataFields: []DataField{
 					{
-						OwnerType: "citizen",
-						OwnerID:   "user" + string(rune('0'+i)),
-						Fields:    []string{"person.permanentAddress"},
+						OwnerType:  "citizen",
+						OwnerID:    "user" + string(rune('0'+i)),
+						OwnerEmail: "user" + string(rune('0'+i)) + "@example.com",
+						Fields:     []string{"person.permanentAddress"},
 					},
 				},
 			}
@@ -492,9 +480,10 @@ func TestConsentEngine_UpdateConsentWithGrantDuration(t *testing.T) {
 		SessionID: "session_123",
 		DataFields: []DataField{
 			{
-				OwnerType: "citizen",
-				OwnerID:   "user123",
-				Fields:    []string{"person.permanentAddress"},
+				OwnerType:  "citizen",
+				OwnerID:    "user123",
+				OwnerEmail: "user123@example.com",
+				Fields:     []string{"person.permanentAddress"},
 			},
 		},
 	}

--- a/exchange/consent-engine/main.go
+++ b/exchange/consent-engine/main.go
@@ -156,6 +156,10 @@ func (s *apiServer) createConsent(w http.ResponseWriter, r *http.Request) {
 			utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: fmt.Sprintf("data_fields[%d].owner_id is required and cannot be empty", i)})
 			return
 		}
+		if dataField.OwnerEmail == "" {
+			utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: fmt.Sprintf("data_fields[%d].owner_email is required and cannot be empty", i)})
+			return
+		}
 		if len(dataField.Fields) == 0 {
 			utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: fmt.Sprintf("data_fields[%d].fields is required and cannot be empty", i)})
 			return
@@ -313,9 +317,9 @@ func (s *apiServer) getConsentsByDataOwner(w http.ResponseWriter, r *http.Reques
 			return nil, http.StatusInternalServerError, fmt.Errorf(ErrConsentGetFailed+": %w", err)
 		}
 		return map[string]interface{}{
-			"data_owner": dataOwner,
-			"consents":   records,
-			"count":      len(records),
+			"owner_id": dataOwner,
+			"consents": records,
+			"count":    len(records),
 		}, http.StatusOK, nil
 	})
 }
@@ -440,6 +444,10 @@ func (s *apiServer) processConsentPortalRequest(w http.ResponseWriter, r *http.R
 		}
 		if dataField.OwnerID == "" {
 			utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: fmt.Sprintf("data_fields[%d].owner_id is required and cannot be empty", i)})
+			return
+		}
+		if dataField.OwnerEmail == "" {
+			utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: fmt.Sprintf("data_fields[%d].owner_email is required and cannot be empty", i)})
 			return
 		}
 		if len(dataField.Fields) == 0 {

--- a/exchange/consent-engine/models/consent_workflow.go
+++ b/exchange/consent-engine/models/consent_workflow.go
@@ -10,7 +10,8 @@ type ConsentWorkflowRequest struct {
 
 // DataField represents a data field request in the consent workflow
 type DataField struct {
-	OwnerType string   `json:"owner_type"`
-	OwnerID   string   `json:"owner_id"`
-	Fields    []string `json:"fields"`
+	OwnerType  string   `json:"owner_type"`
+	OwnerID    string   `json:"owner_id"`
+	OwnerEmail string   `json:"owner_email"`
+	Fields     []string `json:"fields"`
 }


### PR DESCRIPTION
added `owner_email` to ConsentRecord and PortalView objects.. 

1. `POST /consents` you must now specify `owner_email` and get ConsentRecord object
```
{
    "consent_id": "consent_6a1409fe",
    "owner_id": "33333",
    "owner_email": "test@email.com",
    "app_id": "passport-app",
    "status": "pending",
    "type": "realtime",
    "created_at": "2025-09-18T12:33:21.407896+05:30",
    "updated_at": "2025-09-18T12:33:21.407896+05:30",
    "expires_at": "2025-10-18T12:33:21.407844+05:30",
    "grant_duration": "30d",
    "fields": [
        "personInfo.permanentAddress"
    ],
    "session_id": "session_123",
    "consent_portal_url": "http://localhost:5173/?consent_id=consent_6a1409fe"
}
```

2. `GET /consents/:consentId` you get PortalView object
```
{
    "app_display_name": "Passport App",
    "created_at": "2025-09-18T12:33:21.407896+05:30",
    "fields": [
        "personInfo.permanentAddress"
    ],
    "owner_name": "33333",
    "owner_email": "test@email.com",
    "status": "pending",
    "type": "realtime"
}
```