### PR TITLE
bug: update POST /consents, update PUT/PATCH /consents/:consentId

### DIFF
--- a/exchange/consent-engine/api_endpoint_test.go
+++ b/exchange/consent-engine/api_endpoint_test.go
@@ -450,7 +450,7 @@ func TestPUTConsentsWithGrantDuration(t *testing.T) {
 	}
 
 	jsonBody, _ = json.Marshal(updateReq)
-	req = httptest.NewRequest("PUT", "/consents/"+consentID, bytes.NewBuffer(jsonBody))
+	req = httptest.NewRequest("PATCH", "/consents/"+consentID, bytes.NewBuffer(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
 
@@ -458,7 +458,7 @@ func TestPUTConsentsWithGrantDuration(t *testing.T) {
 
 	// Verify response
 	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+		t.Errorf("Expected status %d, got %d. Response body: %s", http.StatusOK, w.Code, w.Body.String())
 	}
 
 	var response map[string]interface{}

--- a/exchange/consent-engine/engine_test.go
+++ b/exchange/consent-engine/engine_test.go
@@ -189,47 +189,6 @@ func TestConsentEngine_FindExistingConsent(t *testing.T) {
 	}
 }
 
-// TestConsentEngine_UpdateConsentRecord tests direct record updates
-func TestConsentEngine_UpdateConsentRecord(t *testing.T) {
-	consentPortalURL := getEnvOrDefault("TEST_CONSENT_PORTAL_URL", "http://localhost:5173")
-	engine := NewConsentEngine(consentPortalURL)
-
-	// Create a consent record first
-	req := ConsentRequest{
-		AppID:     "passport-app",
-		Purpose:   "passport_application",
-		SessionID: "session_123",
-		DataFields: []DataField{
-			{
-				OwnerType:  "citizen",
-				OwnerID:    "user123",
-				OwnerEmail: "user123@example.com",
-				Fields:     []string{"person.permanentAddress"},
-			},
-		},
-	}
-
-	createdRecord, err := engine.CreateConsent(req)
-	if err != nil {
-		t.Fatalf("CreateConsent failed: %v", err)
-	}
-
-	// Update the record directly
-	createdRecord.UpdatedAt = time.Now()
-
-	err = engine.UpdateConsentRecord(createdRecord)
-	if err != nil {
-		t.Fatalf("UpdateConsentRecord failed: %v", err)
-	}
-
-	// Verify the update
-	_, err = engine.GetConsentStatus(createdRecord.ConsentID)
-	if err != nil {
-		t.Fatalf("GetConsentStatus failed: %v", err)
-	}
-
-}
-
 // TestConsentEngine_StatusTransitions tests status transition validation
 func TestConsentEngine_StatusTransitions(t *testing.T) {
 	// Test valid transitions
@@ -238,13 +197,32 @@ func TestConsentEngine_StatusTransitions(t *testing.T) {
 		to    ConsentStatus
 		valid bool
 	}{
+		// Pending state transitions
 		{StatusPending, StatusApproved, true},
 		{StatusPending, StatusRejected, true},
+		{StatusPending, StatusExpired, true},
+
+		// Approved state transitions
 		{StatusApproved, StatusApproved, true}, // Direct approval
 		{StatusApproved, StatusRejected, true}, // Direct rejection
-		{StatusRejected, StatusPending, true},  // Retry
-		{StatusApproved, StatusPending, false}, // Invalid
-		{StatusRejected, StatusApproved, true}, // Valid - allow direct approval from rejected
+		{StatusApproved, StatusRevoked, true},  // User revocation
+		{StatusApproved, StatusExpired, true},  // Expiry
+
+		// Terminal states - can only transition to expired or stay the same
+		{StatusRejected, StatusExpired, true}, // Rejected -> Expired
+		{StatusExpired, StatusExpired, true},  // Expired -> Expired
+		{StatusRevoked, StatusExpired, true},  // Revoked -> Expired
+
+		// Invalid transitions from terminal states
+		{StatusRejected, StatusPending, false},  // Terminal state cannot go back to pending
+		{StatusRejected, StatusApproved, false}, // Terminal state cannot go back to approved
+		{StatusExpired, StatusPending, false},   // Terminal state cannot go back to pending
+		{StatusExpired, StatusApproved, false},  // Terminal state cannot go back to approved
+		{StatusRevoked, StatusPending, false},   // Terminal state cannot go back to pending
+		{StatusRevoked, StatusApproved, false},  // Terminal state cannot go back to approved
+
+		// Invalid transitions from approved
+		{StatusApproved, StatusPending, false}, // Cannot go back to pending
 	}
 
 	for _, tt := range validTransitions {
@@ -532,4 +510,216 @@ func TestConsentEngine_UpdateConsentWithGrantDuration(t *testing.T) {
 	if updatedRecord.Status != string(StatusApproved) {
 		t.Errorf("Expected status %s, got %s", string(StatusApproved), updatedRecord.Status)
 	}
+}
+
+// TestRejectedConsentReuseIssue tests the issue where rejected consents create new records instead of reusing
+func TestRejectedConsentReuseIssue(t *testing.T) {
+	// Create a new consent engine
+	engine := NewConsentEngine("http://localhost:5173")
+
+	// Create initial consent request
+	req1 := ConsentRequest{
+		AppID:         "test-app",
+		Purpose:       "testing",
+		SessionID:     "session123",
+		GrantDuration: "1h",
+		DataFields: []DataField{
+			{
+				OwnerType:  "person",
+				OwnerID:    "user123",
+				OwnerEmail: "user@example.com",
+				Fields:     []string{"name", "email"}, // 2 fields
+			},
+		},
+	}
+
+	// Create the first consent record
+	record1, err := engine.ProcessConsentRequest(req1)
+	if err != nil {
+		t.Fatalf("Failed to create first consent: %v", err)
+	}
+
+	t.Logf("First consent created: ID=%s, Status=%s", record1.ConsentID, record1.Status)
+
+	// Reject the consent
+	updateReq := UpdateConsentRequest{
+		Status:    StatusRejected,
+		UpdatedBy: "test-user",
+		Reason:    "testing rejection",
+	}
+
+	rejectedRecord, err := engine.UpdateConsent(record1.ConsentID, updateReq)
+	if err != nil {
+		t.Fatalf("Failed to reject consent: %v", err)
+	}
+
+	if rejectedRecord.Status != string(StatusRejected) {
+		t.Errorf("Expected status to be rejected, got %s", rejectedRecord.Status)
+	}
+
+	t.Logf("Consent rejected: ID=%s, Status=%s", rejectedRecord.ConsentID, rejectedRecord.Status)
+
+	// Now send the same request but with different number of fields
+	req2 := ConsentRequest{
+		AppID:         "test-app",
+		Purpose:       "testing",
+		SessionID:     "session456", // Different session
+		GrantDuration: "1h",
+		DataFields: []DataField{
+			{
+				OwnerType:  "person",
+				OwnerID:    "user123",
+				OwnerEmail: "user@example.com",
+				Fields:     []string{"name", "email", "phone"}, // 3 fields instead of 2
+			},
+		},
+	}
+
+	// This should reuse the existing rejected record, not create a new one
+	record2, err := engine.ProcessConsentRequest(req2)
+	if err != nil {
+		t.Fatalf("Failed to process second consent request: %v", err)
+	}
+
+	t.Logf("Second consent processed: ID=%s, Status=%s", record2.ConsentID, record2.Status)
+
+	// CORRECT BEHAVIOR: When a consent is rejected, we should create a NEW record, not reuse the old one
+	if record2.ConsentID == record1.ConsentID {
+		t.Errorf("Expected to create NEW consent ID, but reused existing ID %s", record1.ConsentID)
+		t.Logf("ISSUE: Reused existing rejected consent record when it should create a new one")
+	} else {
+		t.Logf("SUCCESS: Created new consent record as expected for rejected consent")
+	}
+
+	// Verify the record is now pending
+	if record2.Status != string(StatusPending) {
+		t.Errorf("Expected status to be pending, got %s", record2.Status)
+	}
+
+	// Verify the fields were updated
+	expectedFields := []string{"name", "email", "phone"}
+	if len(record2.Fields) != len(expectedFields) {
+		t.Errorf("Expected %d fields, got %d", len(expectedFields), len(record2.Fields))
+	}
+
+	// Stop the background process
+	engine.StopBackgroundExpiryProcess()
+}
+
+// TestConsentReuseLogic tests the correct behavior for consent record reuse based on status
+func TestConsentReuseLogic(t *testing.T) {
+	// Create a new consent engine
+	engine := NewConsentEngine("http://localhost:5173")
+
+	baseReq := ConsentRequest{
+		AppID:         "test-app",
+		Purpose:       "testing",
+		SessionID:     "session123",
+		GrantDuration: "1h",
+		DataFields: []DataField{
+			{
+				OwnerType:  "person",
+				OwnerID:    "user123",
+				OwnerEmail: "user@example.com",
+				Fields:     []string{"name", "email"},
+			},
+		},
+	}
+
+	// Test 1: Pending records should be reused
+	t.Log("=== Test 1: Pending records should be reused ===")
+	record1, err := engine.ProcessConsentRequest(baseReq)
+	if err != nil {
+		t.Fatalf("Failed to create first consent: %v", err)
+	}
+	t.Logf("First consent: ID=%s, Status=%s", record1.ConsentID, record1.Status)
+
+	// Send same request - should reuse pending record
+	baseReq.SessionID = "session456" // Different session
+	record2, err := engine.ProcessConsentRequest(baseReq)
+	if err != nil {
+		t.Fatalf("Failed to process second request: %v", err)
+	}
+	t.Logf("Second request: ID=%s, Status=%s", record2.ConsentID, record2.Status)
+
+	if record2.ConsentID != record1.ConsentID {
+		t.Errorf("Expected to reuse pending consent ID %s, but got new ID %s", record1.ConsentID, record2.ConsentID)
+	} else {
+		t.Logf("✓ SUCCESS: Reused pending consent record")
+	}
+
+	// Test 2: Rejected records should NOT be reused
+	t.Log("\n=== Test 2: Rejected records should NOT be reused ===")
+	updateReq := UpdateConsentRequest{
+		Status:    StatusRejected,
+		UpdatedBy: "test-user",
+		Reason:    "testing rejection",
+	}
+
+	rejectedRecord, err := engine.UpdateConsent(record1.ConsentID, updateReq)
+	if err != nil {
+		t.Fatalf("Failed to reject consent: %v", err)
+	}
+	t.Logf("Consent rejected: ID=%s, Status=%s", rejectedRecord.ConsentID, rejectedRecord.Status)
+
+	// Send same request after rejection - should create NEW record
+	baseReq.SessionID = "session789"
+	record3, err := engine.ProcessConsentRequest(baseReq)
+	if err != nil {
+		t.Fatalf("Failed to process third request: %v", err)
+	}
+	t.Logf("Third request: ID=%s, Status=%s", record3.ConsentID, record3.Status)
+
+	if record3.ConsentID == record1.ConsentID {
+		t.Errorf("Expected to create NEW consent ID, but reused rejected ID %s", record1.ConsentID)
+	} else {
+		t.Logf("✓ SUCCESS: Created new consent record after rejection")
+	}
+
+	// Test 3: Approved records should NOT be reused
+	t.Log("\n=== Test 3: Approved records should NOT be reused ===")
+	approveReq := UpdateConsentRequest{
+		Status:    StatusApproved,
+		UpdatedBy: "test-user",
+		Reason:    "testing approval",
+	}
+
+	approvedRecord, err := engine.UpdateConsent(record3.ConsentID, approveReq)
+	if err != nil {
+		t.Fatalf("Failed to approve consent: %v", err)
+	}
+	t.Logf("Consent approved: ID=%s, Status=%s", approvedRecord.ConsentID, approvedRecord.Status)
+
+	// Send same request after approval - should create NEW record
+	baseReq.SessionID = "session999"
+	record4, err := engine.ProcessConsentRequest(baseReq)
+	if err != nil {
+		t.Fatalf("Failed to process fourth request: %v", err)
+	}
+	t.Logf("Fourth request: ID=%s, Status=%s", record4.ConsentID, record4.Status)
+
+	if record4.ConsentID == record3.ConsentID {
+		t.Errorf("Expected to create NEW consent ID, but reused approved ID %s", record3.ConsentID)
+	} else {
+		t.Logf("✓ SUCCESS: Created new consent record after approval")
+	}
+
+	// Test 4: Only ONE pending record per (appId, ownerId, ownerEmail) tuple
+	t.Log("\n=== Test 4: Only ONE pending record per tuple ===")
+	// Send another request - should reuse the pending record from Test 3
+	baseReq.SessionID = "session1000"
+	record5, err := engine.ProcessConsentRequest(baseReq)
+	if err != nil {
+		t.Fatalf("Failed to process fifth request: %v", err)
+	}
+	t.Logf("Fifth request: ID=%s, Status=%s", record5.ConsentID, record5.Status)
+
+	if record5.ConsentID != record4.ConsentID {
+		t.Errorf("Expected to reuse pending consent ID %s, but got new ID %s", record4.ConsentID, record5.ConsentID)
+	} else {
+		t.Logf("✓ SUCCESS: Reused pending consent record (only one pending per tuple)")
+	}
+
+	// Stop the background process
+	engine.StopBackgroundExpiryProcess()
 }


### PR DESCRIPTION
## Testing

```bash
cd exchange/consent-engine
go mod tidy
ASGARDEO_JWKS_URL=https://api.asgardeo.io/t/lankasoftwarefoundation/oauth2/jwks CONSENT_PORTAL_URL=http://localhost:5173 go run main.go engine.go jwt_verifier.go constants.go
```

## Code Updates
- enforce only 1 pending record can exist for each unique (appId, ownerId, ownerEmail) tuple
- fixes API endpoint routing to follow RESTful principles: fixed routing to use `POST /consents` for creation only, `PUT /consents/{id}` for full updates, `PATCH /consents/{id}` for partial updates, and `DELETE /consents/{id}` for revocation
-  implemented proper consent record reuse behavior. `POST /consents` now performs PATCH-like updates when reusing existing pending records, updating fields, updated_at, grant_duration, expires_at, and session_id
- ensure `grant_duration` is "1h" default when not specified in requests
- Status Transitions: Updated transition rules with `pending` → `approved/rejected/expired`, `approved` → `approved/rejected/revoked/expired`, terminal states → expired only
- Terminal States: expired and revoked are now terminal states that cannot transition back to active states