### PR TITLE
allow provider_id to be null

### DIFF
--- a/api-server-go/models/provider_metadata.go
+++ b/api-server-go/models/provider_metadata.go
@@ -8,8 +8,8 @@ type ProviderMetadataUpdateRequest struct {
 
 // ProviderFieldGrant represents a field grant for a specific consumer
 type ProviderFieldGrant struct {
-	FieldName     string `json:"fieldName" validate:"required"`
-	GrantDuration string `json:"grantDuration" validate:"required"`
+	FieldName     string `json:"field_name" validate:"required"`
+	GrantDuration string `json:"grant_duration" validate:"required"`
 }
 
 // ProviderMetadataField represents a field in the provider metadata JSON

--- a/exchange/policy-decision-point/database.go
+++ b/exchange/policy-decision-point/database.go
@@ -210,7 +210,6 @@ func (ds *DatabaseService) UpdateProviderMetadata(metadata *models.ProviderMetad
 			field.Owner = "external"
 		}
 		// Allow NULL providers - don't set a default value
-		// The database schema now allows NULL values for the provider column
 		if field.AccessControlType == "" {
 			field.AccessControlType = "public"
 		}
@@ -227,7 +226,11 @@ func (ds *DatabaseService) UpdateProviderMetadata(metadata *models.ProviderMetad
 			allow_list = EXCLUDED.allow_list,
 			updated_at = EXCLUDED.updated_at`
 
-		// Handle NULL provider values
+		// Handle NULL provider values - CRITICAL DATABASE CONSTRAINT BEHAVIOR
+		// Empty strings from metadata_handler.go are converted to NULL to satisfy
+		// database schema requirements. PREREQUISITE: The provider column must be
+		// altered to allow NULL values to support fields without associated providers,
+		// bypassing foreign key constraints.
 		var providerValue interface{}
 		if field.Provider == "" {
 			providerValue = nil

--- a/exchange/policy-decision-point/metadata_handler.go
+++ b/exchange/policy-decision-point/metadata_handler.go
@@ -129,10 +129,15 @@ func (h *MetadataHandler) updateFieldMetadata(metadata *models.ProviderMetadata,
 	if !exists {
 		// Create new field metadata with default values
 		field = models.ProviderMetadataField{
-			Owner:             "external", // Default owner
-			Provider:          "",         // Empty string will be converted to NULL in database
-			ConsentRequired:   false,      // Default to false
-			AccessControlType: "public",   // Default to public
+			Owner:    "external", // Default owner
+			Provider: "",         // CRITICAL: Empty string will be converted to NULL in database
+			// This conversion happens in database.go UpdateProviderMetadata() and is required
+			// PREREQUISITE: The database schema must be updated to allow NULL values for the
+			// provider column to support fields that don't have an associated provider.
+			// This affects foreign key constraints and query behavior - NULL providers bypass
+			// foreign key validation.
+			ConsentRequired:   false,    // Default to false
+			AccessControlType: "public", // Default to public
 			AllowList:         []models.PDPAllowListEntry{},
 		}
 	}

--- a/exchange/policy-decision-point/metadata_handler.go
+++ b/exchange/policy-decision-point/metadata_handler.go
@@ -129,13 +129,10 @@ func (h *MetadataHandler) updateFieldMetadata(metadata *models.ProviderMetadata,
 	if !exists {
 		// Create new field metadata with default values
 		field = models.ProviderMetadataField{
-			Owner:    "external", // Default owner
-			Provider: "",         // CRITICAL: Empty string will be converted to NULL in database
-			// This conversion happens in database.go UpdateProviderMetadata() and is required
-			// PREREQUISITE: The database schema must be updated to allow NULL values for the
-			// provider column to support fields that don't have an associated provider.
-			// This affects foreign key constraints and query behavior - NULL providers bypass
-			// foreign key validation.
+			Owner:    "external",       // Default owner
+			Provider: "system-default", // Use system-default provider for fields without specific provider
+			// This ensures data integrity by maintaining foreign key relationships
+			// The 'system-default' entity must exist in the entities table
 			ConsentRequired:   false,    // Default to false
 			AccessControlType: "public", // Default to public
 			AllowList:         []models.PDPAllowListEntry{},

--- a/exchange/policy-decision-point/models/provider_metadata.go
+++ b/exchange/policy-decision-point/models/provider_metadata.go
@@ -8,8 +8,8 @@ type ProviderMetadataUpdateRequest struct {
 
 // ProviderFieldGrant represents a field grant for a specific consumer
 type ProviderFieldGrant struct {
-	FieldName     string `json:"fieldName" validate:"required"`
-	GrantDuration string `json:"grantDuration" validate:"required"`
+	FieldName     string `json:"field_name" validate:"required"`
+	GrantDuration string `json:"grant_duration" validate:"required"`
 }
 
 // ProviderMetadataField represents a field in the provider metadata JSON

--- a/exchange/policy-decision-point/test_metadata_fix.sh
+++ b/exchange/policy-decision-point/test_metadata_fix.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Test script to verify the metadata update fix
+echo "=== Testing Policy Decision Point Metadata Update Fix ==="
+echo ""
+
+# Test the metadata update endpoint with the same payload that was failing
+echo "Testing metadata update endpoint..."
+echo ""
+
+# Test data matching the failing request
+TEST_DATA='{
+  "application_id": "passport-app",
+  "fields": [
+    {
+      "field_name": "person.fullName",
+      "grant_duration": "P30D"
+    }
+  ]
+}'
+
+echo "Request payload:"
+echo "$TEST_DATA" | jq .
+echo ""
+
+# Test the endpoint (assuming it's running on localhost:8082)
+echo "Sending request to /metadata/update..."
+echo ""
+
+curl -X POST http://localhost:8082/metadata/update \
+  -H "Content-Type: application/json" \
+  -d "$TEST_DATA" \
+  -w "\nHTTP Status: %{http_code}\n" \
+  -v
+
+echo ""
+echo "Test completed."

--- a/exchange/policy-decision-point/test_system_provider.sh
+++ b/exchange/policy-decision-point/test_system_provider.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Test script to verify system-default provider is used
+echo "=== Testing System Default Provider Implementation ==="
+echo ""
+
+# Test data with a field that doesn't have a specific provider
+TEST_DATA='{
+  "application_id": "system-test-app",
+  "fields": [
+    {
+      "field_name": "system.generatedField",
+      "grant_duration": "P30D"
+    }
+  ]
+}'
+
+echo "Request payload:"
+echo "$TEST_DATA" | jq .
+echo ""
+
+# Test the endpoint
+echo "Sending request to /metadata/update..."
+echo ""
+
+curl -X POST http://localhost:8082/metadata/update \
+  -H "Content-Type: application/json" \
+  -d "$TEST_DATA" \
+  -w "\nHTTP Status: %{http_code}\n" \
+  -v
+
+echo ""
+echo "Test completed."


### PR DESCRIPTION
Problem: There is a foreign key constraint issue that was causing the "Failed to save metadata" error when calling PDP's `POST /metadata/update` endpoint

Fix: update the policy-decision-point service to use 'system-default' as the default provider ID instead of NULL or empty strings

### To connect to production DB
```bash
cd /exchange/policy-decision-point && export CHOREO_DB_PDP_HOSTNAME=pg-41200aa141064e6cbabf311dce37c04a-opendifd1461627769-choreo-o.h.aivencloud.com && export CHOREO_DB_PDP_PORT=19847 && export CHOREO_DB_PDP_USERNAME=avnadmin && export CHOREO_DB_PDP_PASSWORD=AVNS_HwUxELSQImHrLu9XnYD && export CHOREO_DB_PDP_DATABASENAME=defaultdb && ./policy-decision-point &
```

```bash
curl -X POST http://localhost:8082/metadata/update -H "Content-Type: application/json" -d '{"application_id": "passport-app", "fields": [{"field_name": "person.newField", "grant_duration": "P30D"}]}'
```

You should get
`{"success":true,"message":"Updated 1 fields for application passport-app","updated":1}`
